### PR TITLE
Add ncc to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -176,6 +176,12 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "@zeit/ncc": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.21.0.tgz",
+      "integrity": "sha512-RUMdvVK/w78oo+yBjruZltt0kJXYar2un/1bYQ2LuHG7GmFVm+QjxzEmySwREctaJdEnBvlMdUNWd9hXHxEI3g==",
+      "dev": true
+    },
     "aggregate-error": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "shelljs": "^0.8.3"
   },
   "devDependencies": {
+    "@zeit/ncc": "^0.21.0",
     "husky": "^4.0.7",
     "lint-staged": "^9.5.0",
     "prettier": "^1.19.1"


### PR DESCRIPTION
It's common practice that npm projects run without installing anything globally on your machine: you should be able to clone the repo, run `npm install` and then run scripts in `package.json` right away (eg, run `npm run build` succesfully in this case). So adding `ncc` as dev dependency sounds like a good idea.